### PR TITLE
Remove duplicate command parts in using-docker.md

### DIFF
--- a/src/wax/using-docker.md
+++ b/src/wax/using-docker.md
@@ -26,7 +26,7 @@ Next, complete the steps 1-6 on [Copying the Demo template](../setting-up-your-s
 
 3. Create and access an interactive bash container from the image by running:
   ```sh
-  docker run -it --rm -v ${PWD}:/wax --name wax -p 4000:4000 minicomp/wax bash minicomp/wax bash
+  docker run -it --rm -v ${PWD}:/wax --name wax -p 4000:4000 minicomp/wax bash
   ```
 4. **Inside the container**, update the dependencies by running:
   ```sh


### PR DESCRIPTION
Going through the wax documentation for docker, I discovered that the image name and command were given twice in the command line example, which I believe to be a mistake.